### PR TITLE
fix: add homepage & repository metadata for npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,6 +2,11 @@
   "name": "shex-codegen",
   "version": "0.3.26",
   "description": "",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/ludwigschubi/shex-codegen.git"
+  },
+  "homepage": "https://github.com/ludwigschubi/shex-codegen#readme",
   "main": "lib/index.js",
   "browser": "browser/browser.js",
   "scripts": {


### PR DESCRIPTION
This way the link to the github repo will show up on the npm package page.