### PR TITLE
feat: support rdf:LangString datatype (+test)

### DIFF
--- a/src/visitors/typescript/generates.ts
+++ b/src/visitors/typescript/generates.ts
@@ -288,6 +288,8 @@ export function generateTsType(valueExpr: any, toCreate?: boolean) {
     return toCreate ? 'Date | Literal' : 'Date';
   } else if (valueExpr?.datatype === ns.xsd('string')) {
     return toCreate ? 'string | Literal' : 'string';
+  } else if (valueExpr?.datatype === ns.rdfs('langString')) {
+    return toCreate ? 'string | Literal' : 'string';
   } else if (valueExpr?.datatype) {
     return valueExpr?.datatype;
   } else if (typeof valueExpr === 'string') {

--- a/test/__snapshots__/generate.test.ts.snap
+++ b/test/__snapshots__/generate.test.ts.snap
@@ -733,6 +733,7 @@ export type BasicContainerShapeUpdateArgs = Partial<BasicContainerShapeCreateArg
 
 export type ResourceShape = {
   id: string; // the url of a node of this shape
+  description: string; // Gives a description for the resource
   size: number; // Size of Container
   mtime: number; // Time of Container creation created
   modified: Date; // Time the Container was modified
@@ -742,6 +743,7 @@ export type ResourceShape = {
 
 export type ResourceShapeCreateArgs = {
   id?: string | NamedNode; // the url to match or create the node with e.g. 'https://example.com#this', 'https://example.com/profile/card#me'
+  description: string | Literal; // Gives a description for the resource
   size: number | Literal; // Size of Container
   mtime: number | Literal; // Time of Container creation created
   modified: Date | Literal; // Time the Container was modified
@@ -770,6 +772,7 @@ export enum BasicContainerShapeContext {
 
 export enum ResourceShapeContext {
   type = 'rdf:type',
+  description = 'terms:description',
   size = 'st:size',
   mtime = 'st:mtime',
   modified = 'terms:modified',
@@ -801,6 +804,8 @@ ldp:BasicContainerShape EXTRA a {
 ldp:ResourceShape EXTRA a {
   a [ ldp:Resource ]
     // rdfs:comment  \\"Defines the node as a Resource\\" ;
+  terms:description rdfs:langString
+    // rdfs:comment  \\"Gives a description for the resource\\" ;
   st:size xsd:integer
     // rdfs:comment  \\"Size of Container\\" ;
   st:mtime xsd:decimal

--- a/test/shapes/ldpShapes.shex
+++ b/test/shapes/ldpShapes.shex
@@ -23,6 +23,8 @@ ldp:BasicContainerShape EXTRA a {
 ldp:ResourceShape EXTRA a {
   a [ ldp:Resource ]
     // rdfs:comment  "Defines the node as a Resource" ;
+  terms:description rdfs:langString
+    // rdfs:comment  "Gives a description for the resource" ;
   st:size xsd:integer
     // rdfs:comment  "Size of Container" ;
   st:mtime xsd:decimal


### PR DESCRIPTION
As of current, datatype `rdf:langString` is not supported.

If we try to convert the following shex
```
<#AccessNeedDescriptionShape> {
  a [ interop:AccessNeedDescription ] ;
  interop:inAccessDescriptionSet  IRI  // shex:reference <#AccessDescriptionSetShape> ;
  interop:hasAccessNeed           IRI  // shex:reference <#AccessNeedShape> ;
  skos:prefLabel                  rdf:langString // <- Unknown datatype
}
```

Then the code generation fails because it applies the type as a raw string.
```
SyntaxError: ';' expected. (204:18)
      202 | export type ResourceShape = {
      203 | id: string; // the url of a node of this shape
    > 204 | description: http://www.w3.org/2000/01/rdf-schema#langString;
          |                  ^
      205 | size: number; // Size of Container
      206 | mtime: number; // Time of Container creation created
      207 | modified: Date; // Time the Container was modified

      185 |     // prettier formatting
      186 |     const prettierConfig = await prettier.resolveConfig(process.cwd());
    > 187 |     const formatted = prettier.format(content, {
          |                                ^
      188 |       ...prettierConfig,
      189 |       filepath: generates,
      190 |     });

      at e (node_modules/prettier/parser-typescript.js:1:411)
      at Object.parse (node_modules/prettier/parser-typescript.js:1:3072809)
      at Object.parse (node_modules/prettier/index.js:13625:19)
      at coreFormat (node_modules/prettier/index.js:14899:14)
      at format (node_modules/prettier/index.js:15131:14)
      at node_modules/prettier/index.js:57542:12
      at Object.format (node_modules/prettier/index.js:57562:12)
      at src/generate.ts:187:32
      at fulfilled (lib/generate.js:13:24)
```

The following code change fixes the issue without breaking the test.